### PR TITLE
Add ActiveRecord DSL

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,10 @@ Rails:
 Naming/AccessorMethodName:
   Enabled: false
 
+Naming/ClassAndModuleCamelCase:
+  Exclude:
+    - 'spec/**/*.rb'
+
 Style/TrivialAccessors:
   Enabled: false
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ clone.profile.name
 - [Execute finalize block](#finalize)
 - [Traits](#traits)
 - [Execution order](#execution_order)
+- [ActiveRecord DSL](#ar_dsl)
 - [Customization](#customization)
 
 ### <a name="configuration"></a>Configuration
@@ -378,6 +379,38 @@ For ActiveRecord:
 - nullify attributes
 - run `finalize` blocks
 The order of `finalize` blocks is the order they've been written.
+
+### <a name="ar_dsl"></a>Active Record DSL
+
+Clowne provides an optional ActiveRecord integration which allows you to configure cloners in your models and adds a shortcut to invoke cloners (`#clowne` method). (Note: that's exactly the way [`amoeba`](https://github.com/amoeba-rb/amoeba) works).
+
+To enable this integration you must require `"clowne/adapters/active_record/dsl"` somewhere in your app, e.g. in initializer:
+
+```ruby
+# config/initializers/clowne.rb
+require "clowne/adapters/active_record/dsl"
+```
+
+Now you can specify cloning configs in your AR models:
+
+```ruby
+class User < ActiveRecord::Base
+  clowne_config do
+    include_associations :profile
+
+    nullify :email
+
+    # whatever available for your cloners,
+    # active_record adapter is set implicitly here
+  end
+end
+```
+
+And then you can clone objects like this:
+
+```ruby
+cloned_user = user.clowne(traits: my_traits, **params)
+```
 
 ### <a name="customization"></a>Customization
 

--- a/lib/clowne/adapters/active_record/dsl.rb
+++ b/lib/clowne/adapters/active_record/dsl.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Clowne
+  module Adapters
+    # Extend ActiveRecord with Clowne DSL and methods
+    module ActiveRecordDSL
+      module InstanceMethods # :nodoc:
+        # Shortcut to call class's cloner call with self
+        def clowne(*args)
+          self.class.cloner_class.call(self, *args)
+        end
+      end
+
+      module ClassMethods # :nodoc:
+        def clowne_config(options = {}, &block)
+          if options.delete(:inherit) != false && superclass.respond_to?(:cloner_class)
+            parent_cloner = superclass.cloner_class
+          end
+
+          parent_cloner ||= Clowne::Cloner
+          cloner = instance_variable_set(:@_clowne_cloner, Class.new(parent_cloner))
+          cloner.adapter :active_record
+          cloner.instance_exec(&block)
+        end
+      end
+    end
+  end
+end
+
+ActiveSupport.on_load(:active_record) do
+  ::ActiveRecord::Base.extend Clowne::Adapters::ActiveRecordDSL::ClassMethods
+  ::ActiveRecord::Base.include Clowne::Adapters::ActiveRecordDSL::InstanceMethods
+end

--- a/spec/clowne/integrations/active_record_dsl_spec.rb
+++ b/spec/clowne/integrations/active_record_dsl_spec.rb
@@ -1,0 +1,99 @@
+require 'clowne/adapters/active_record/dsl'
+
+describe 'AR DSl', :cleandb do
+  before(:all) do
+    module AR_DSL
+      class User < ActiveRecord::Base
+        has_many :posts, class_name: 'AR_DSL::Post', foreign_key: :owner_id
+
+        clowne_config do
+          include_association :posts
+
+          nullify :email
+        end
+      end
+
+      class Admin < User
+        clowne_config do
+          include_association :posts, :with_topics
+        end
+      end
+
+      class Post < ActiveRecord::Base
+        has_one :account, class_name: 'AR_DSL::Account'
+        belongs_to :owner, class_name: 'AR_DSL::User'
+
+        clowne_config do
+          include_association :account
+
+          finalize do |source, record, params|
+            record.title = params[:title] || "Clone of #{source.title}"
+          end
+        end
+
+        scope :with_topics, -> { where.not(topic_id: nil) }
+      end
+
+      class DraftPost < Post
+        clowne_config(inherit: false) {}
+      end
+
+      class Account < ActiveRecord::Base
+        belongs_to :post, class_name: 'AR_DSL::Post'
+      end
+    end
+  end
+
+  after(:all) do
+    %w[User Admin Post DraftPost Account].each do |klass|
+      AR_DSL.send(:remove_const, klass)
+    end
+  end
+
+  let!(:user) { AR_DSL::User.create!(name: 'Jack Sparrow', email: 'sparrow@black.pearl.test') }
+
+  let!(:post) do
+    AR_DSL::Post.create!(
+      owner: user, topic_id: 123, title: 'Pirates of XXI century',
+      contents: "Let's rock!"
+    )
+  end
+
+  let!(:draft_post) do
+    AR_DSL::DraftPost.create!(owner: user, topic_id: nil, title: '[wip]', contents: 'TBD')
+  end
+
+  let!(:account) { AR_DSL::Account.create!(post: post, title: 'Union Black') }
+  let!(:draft_account) { AR_DSL::Account.create!(post: draft_post, title: 'Draf of Union Black') }
+
+  describe '#clowne' do
+    it 'uses inline config' do
+      cloned_post = post.clowne(title: 'New Post')
+
+      expect(cloned_post.title).to eq 'New Post'
+      expect(cloned_post.account).not_to be_nil
+      expect(cloned_post.account.title).to eq 'Union Black'
+    end
+
+    it 'works with inherit: false' do
+      cloned_post = draft_post.clowne(title: 'New Post')
+
+      expect(cloned_post.title).to eq '[wip]'
+      expect(cloned_post.account).to be_nil
+    end
+
+    it 'works with inheritance' do
+      admin = AR_DSL::Admin.find(user.id)
+
+      cloned_admin = admin.clowne
+      cloned_user = user.clowne
+
+      expect(cloned_user.email).to be_nil
+      expect(cloned_user.posts.size).to eq 2
+
+      expect(cloned_admin.email).to be_nil
+      expect(cloned_admin.posts.size).to eq 1
+      expect(cloned_admin.posts.first.title).to eq 'Clone of Pirates of XXI century'
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,4 +37,8 @@ RSpec.configure do |config|
         ar_class.instance_variable_defined?(:@_clowne_cloner)
     end
   end
+
+  config.after(:each, cleandb: true) do
+    ActiveRecord::Base.subclasses.each(&:delete_all)
+  end
 end


### PR DESCRIPTION
To write things like this:

```ruby
class User < ActiveRecord::Base
  clowne_config do
    include_associations :profile

    nullify :email

    # whatever available for your cloners,
    # active_record adapter is set implicitly here
  end
end

cloned_user = user.clowne(traits: my_traits, **params)
# it's just a shortcut for
cloned_user = user.class.cloner_class.call(user, *args)
```

This is an **optional feature**, should be explicitly enabled (_required_).