### PR TITLE
Add inline configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,19 +82,19 @@ end
 and call it
 
 ```ruby
-clone = UserCloner.call(User.last, { email: "fake@example.com" })
-clone.persisted?
+cloned = UserCloner.call(User.last, { email: "fake@example.com" })
+cloned.persisted?
 # => false
-clone.save!
-clone.login
+cloned.save!
+cloned.login
 # => nil
-clone.email
+cloned.email
 # => "fake@example.com"
 
 # associations:
-clone.posts.count == User.last.posts.count
+cloned.posts.count == User.last.posts.count
 # => true
-clone.profile.name
+cloned.profile.name
 # => nil
 ```
 
@@ -102,6 +102,8 @@ clone.profile.name
 
 - [Configuration](#configuration)
 - [Include association](#include_association)
+- - [Inline configuration](#config-inline)
+- [Include one association](#include_association)
 - - [Scope](#include_association_scope)
 - - [Options](#include_association_options)
 - - [Multiple associations](#include_associations)
@@ -120,6 +122,39 @@ You can configure the default adapter for cloners:
 ```ruby
 # somewhere in initializers
 Clowne.default_adapter = :active_record
+```
+
+#### <a name="config-inline"></a>Inline Configuration
+
+You can also enhance the cloner configuration inline (i.e. add dynamic declarations):
+
+```ruby
+cloned = UserCloner.call(User.last) do
+  exclude_association :profile
+
+  finalize do |source, record|
+    record.email = "clone_of_#{source.email}"
+  end
+end
+
+cloned.email
+# => "clone_of_john@example.com"
+
+# associations:
+cloned.posts.size == User.last.posts.size
+# => true
+cloned.profile
+# => nil
+```
+
+Inline enhancement doesn't affect the _global_ configuration, so you can use it without any fear.
+
+Thus it's also possible to clone objects without any cloner classes at all by using `Clowne::Cloner`:
+
+```ruby
+cloned = Clowne::Cloner.call(user) do
+  # anything you want!
+end
 ```
 
 ### <a name="include_association"></a>Include one association

--- a/lib/clowne/cloner.rb
+++ b/lib/clowne/cloner.rb
@@ -38,8 +38,8 @@ module Clowne # :nodoc: all
         @traits[name].extend_with(block)
       end
 
-      # rubocop: disable Metrics/AbcSize
-      # rubocop: disable Metrics/MethodLength
+      # rubocop: disable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop: disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def call(object, **options)
         raise(UnprocessableSourceError, 'Nil is not cloneable object') if object.nil?
 
@@ -56,11 +56,13 @@ module Clowne # :nodoc: all
             plan_with_traits(traits)
           end
 
+        plan = Clowne::Planner.enhance(plan, Proc.new) if block_given?
+
         adapter.clone(object, plan, params: options)
       end
 
-      # rubocop: enable Metrics/AbcSize
-      # rubocop: enable Metrics/MethodLength
+      # rubocop: enable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop: enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
       def default_plan
         return @default_plan if instance_variable_defined?(:@default_plan)

--- a/lib/clowne/planner.rb
+++ b/lib/clowne/planner.rb
@@ -5,10 +5,7 @@ require 'clowne/plan'
 module Clowne
   class Planner # :nodoc: all
     class << self
-      # Params:
-      # +cloner+:: Cloner object
-      # +init_plan+:: Init plan
-      # +traits+:: List of traits if any
+      # Compile plan for cloner with traits
       def compile(cloner, traits: nil)
         declarations = cloner.declarations.dup
 
@@ -16,6 +13,16 @@ module Clowne
 
         declarations.each_with_object(Plan.new(cloner.adapter.registry)) do |declaration, plan|
           declaration.compile(plan)
+        end
+      end
+
+      # Extend previously compiled plan with an arbitrary block
+      # NOTE: It doesn't modify the plan itself but return a copy
+      def enhance(plan, block)
+        trait = Clowne::Declarations::Trait.new.tap { |t| t.extend_with(block) }
+
+        trait.compiled.each_with_object(plan.dup) do |declaration, new_plan|
+          declaration.compile(new_plan)
         end
       end
 

--- a/spec/clowne/cloner_spec.rb
+++ b/spec/clowne/cloner_spec.rb
@@ -120,5 +120,37 @@ describe Clowne::Cloner do
         )
       end
     end
+
+    context 'with inline config' do
+      let(:source_class) { Struct.new(:name, :age) }
+
+      let(:source) { source_class.new('John', 28) }
+
+      let(:cloner) do
+        Class.new(Clowne::Cloner) do
+          finalize { |_, record| record.age += 1 }
+        end
+      end
+
+      it 'works', :aggregate_failures do
+        inlined = cloner.call(source) do
+          nullify :name
+
+          finalize { |_, record| record.age *= 2 }
+        end
+
+        expect(inlined).to have_attributes(
+          name: nil,
+          age: 58
+        )
+
+        cloned = cloner.call(source)
+
+        expect(cloned).to have_attributes(
+          name: 'John',
+          age: 29
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
It turned out to be very useful to have the following feature:

```ruby
cloned = UserCloner.call(User.last) do
  exclude_association :profile

  finalize do |source, record|
    record.email = "clone_of_#{source.email}"
  end
end
```