### PR TITLE
Fix `bundle install` on TruffleRuby in CI

### DIFF
--- a/.github/workflows/rspec-truffle.yml
+++ b/.github/workflows/rspec-truffle.yml
@@ -18,6 +18,7 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: truffleruby
+        bundler: latest
         bundler-cache: true
     - name: Run RSpec
       run: |


### PR DESCRIPTION
Changes:
- always use the latest bundler in CI on TruffleRuby

The issue is caused by a bug in `bundler` that is fixed in more recent `bundler` versions. So just updating it resolves this issue. The bug leads to installing JRuby gems (e.g. `activerecord-jdbcsqlite3-adapter`) on TruffleRuby.

Example of error:

```
$ bundle install
/home/runner/.rubies/truffleruby-24.1.1/bin/bundle config --local path /home/runner/work/clowne/clowne/vendor/bundle
/home/runner/.rubies/truffleruby-24.1.1/bin/bundle lock
Fetching gem metadata from https://rubygems.org/..........
Resolving dependencies...
Could not find compatible versions

Because activerecord-jdbcsqlite3-adapter >= 50.0, < 51.0 depends on
activerecord-jdbc-adapter ~> 50.0
and activerecord-jdbc-adapter >= 50.0, < 51.A could not be found in rubygems
repository https://rubygems.org/ or installed locally for any resolution
platforms (x86_64-linux),
  activerecord-jdbcsqlite3-adapter >= 50.0, < 51.0 cannot be used.
And because activerecord-jdbcsqlite3-adapter >= 51.0 depends on
activerecord-jdbc-adapter ~> 51.0
  and activerecord-jdbc-adapter >= 51.0 depends on activerecord ~> 5.1.0,
  activerecord-jdbcsqlite3-adapter >= 50.0 requires activerecord ~> 5.1.0.
So, because Gemfile depends on activerecord-jdbcsqlite3-adapter >= 50.0, < 70.0
  and Gemfile depends on activerecord >= 6.0,
  version solving has failed.

The source contains the following gems matching 'activerecord-jdbc-adapter (>=
50.0, < 51.A)':
  * activerecord-jdbc-adapter-50.1-java
  * activerecord-jdbc-adapter-[50](https://github.com/clowne-rb/clowne/actions/runs/12960864355/job/36155314909#step:3:56).2-java
  * activerecord-jdbc-adapter-50.3-java
  * activerecord-jdbc-adapter-50.4-java
  * activerecord-jdbc-adapter-50.5-java
  * activerecord-jdbc-adapter-50.6-java
  * activerecord-jdbc-adapter-50.7-java
  * activerecord-jdbc-adapter-50.8-java
Error: The process '/home/runner/.rubies/truffleruby-24.1.1/bin/bundle' failed with exit code 6
```